### PR TITLE
Update rfcbot API URL.

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -163,7 +163,7 @@ impl TeamMember {
                      .map(|issue| Item::from_issue(issue, Kind::RFC))
                      .filter(|item| item.url.contains("pull")));
 
-        let mut url = String::from("http://rusty-dash.com/api/fcp/");
+        let mut url = String::from("http://rusty-dash.com/api/");
         url.push_str(&self.login);
 
         let mut resp = reqwest::get(&url)?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -163,7 +163,7 @@ impl TeamMember {
                      .map(|issue| Item::from_issue(issue, Kind::RFC))
                      .filter(|item| item.url.contains("pull")));
 
-        let mut url = String::from("http://rusty-dash.com/api/");
+        let mut url = String::from("https://rfcbot.rs/api/");
         url.push_str(&self.login);
 
         let mut resp = reqwest::get(&url)?;


### PR DESCRIPTION
Sorry!

I forgot to tell you I changed this when I moved the API server over to Rocket. From the logs, it looks like nagbot is the only consumer of this API.